### PR TITLE
Move pcap createSession into fn with try/catch

### DIFF
--- a/bin/findbutton
+++ b/bin/findbutton
@@ -4,10 +4,10 @@ process.env.NODE_ENV = 'test'
 //simple module for finding your button's mac
 
 var int_array_to_hex = require('../index.js').int_array_to_hex;
-var pcap = require('pcap'),
-    pcap_session = pcap.createSession();
+var create_session = require('../index.js').create_session;
+var pcap = require('pcap');
 
-var _ = require("underscore")
+var pcap_session = create_session();
 
 console.log("Watching for arp requests on your local network, please try to press your dash now");
 


### PR DESCRIPTION
instead of implicitly creating a session on index.js import, so we're able to catch on the "no devices" error and suggest that the user try running with elevated privileges.

Maybe this will help the next guy/gal when they get that pcap error trying to run `findbutton` or try to use the module :)