### PR TITLE
Revert "just_emitted" for only MAC address caught

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ var register = function(mac_addresses) {
                              hex_to_int_array(mac_address))) {
                     readStream.emit('detected', mac_address);
                     just_emitted[mac_address] = true;
-                    setTimeout(function () { just_emitted[mad_address] = false; }, 3000);
+                    setTimeout(function () { just_emitted[mac_address] = false; }, 3000);
                 }                
             });
         }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ var register = function(mac_addresses) {
                              hex_to_int_array(mac_address))) {
                     readStream.emit('detected', mac_address);
                     just_emitted[mac_address] = true;
-                    setTimeout(function () { just_emitted = false; }, 3000);
+                    setTimeout(function () { just_emitted[mad_address] = false; }, 3000);
                 }                
             });
         }


### PR DESCRIPTION
The previous mechanism was nuking the entire just_emitted block for all addresses, now it just flips the boolean on the address that's been caught (and just reset).