### PR TITLE
Pin node_pcap to a known working commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/hortinstein/node-dash-button",
   "dependencies": {
-    "pcap": "git+https://github.com/mranney/node_pcap.git",
+    "pcap": "git+https://github.com/mranney/node_pcap.git#d920204745c8b00ef4b7a3fe27d902b263cdb70f",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The `package.json` dependency for the `pcap` library is currently pointing at a GitHub repository, which offers no guarantees of repeatability when installing `node-dash-button`; one of the authors of `node_pcap` could push a change that results in `node-dash-button` breaking.

This change pins the git dependency `pcap` at an (arbitrary) working commit to sure that major changes by the `pcap` devs can't break this package.